### PR TITLE
Security: per-install Node-RED credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v3.7.7 — Security: per-install Node-RED credentials
+
+### 🔒 Security
+- Removed hardcoded Node-RED editor / HTTP credentials and `credentialSecret` from the public image. All installs previously shared the same default user and bcrypt hash, allowing anyone with image access to log into any install on port 1891.
+
+### ✨ Added
+- Add-on options `auth_username` and `auth_password` to configure Node-RED editor / HTTP endpoint credentials. Hashed with bcrypt at startup and applied to `adminAuth`, `httpNodeAuth`, and `httpStaticAuth`.
+- Per-install random `credentialSecret`, generated once and persisted to `/data/credential-secret` (0600).
+
+### ⬆️  Upgrade notes
+- The previous default login no longer works.
+- If `auth_username` or `auth_password` is left blank, Node-RED starts with **no authentication** and a warning is logged to the add-on log. Set both options to enable authentication — recommended, since port 1891 is exposed on the LAN.
+- Encrypted MQTT credentials are not affected: this add-on rewrites `flows.json` from the template on every restart, and MQTT credentials are read from add-on options at runtime.
+
+##  _______________________________________________________
+
 ## v3.7.6 - 2026-04-12
 ### 🐞  Bug Fix
 - Remove the serial port compilation to avoid version conflict issues on ARM64/aarch64

--- a/DOCS.md
+++ b/DOCS.md
@@ -272,6 +272,25 @@ You can see a short live demonstration on my Youtube [channel](https://www.youtu
 ---
 ## Other options
 ---
+### Option: `Node-RED authentication`
+
+The Node-RED editor and HTTP endpoints (port 1891) can be protected with
+basic authentication via the `auth_username` and `auth_password` options:
+
+- **Both set** — the password is hashed with bcrypt on each startup and
+  applied to the editor (`adminAuth`), HTTP-In nodes (`httpNodeAuth`),
+  and static-file routes (`httpStaticAuth`). A confirmation line is
+  written to the add-on log.
+- **Either blank** — Node-RED starts with no authentication and a
+  warning banner is logged. Port 1891 is exposed directly on your LAN,
+  so leaving it open is **not recommended**.
+
+A per-install `credentialSecret` (used by Node-RED to encrypt credentials
+inside flows) is generated automatically on first launch and persisted to
+`/data/credential-secret` (mode 0600). It survives restarts and is unique
+to your installation.
+
+---
 ### Option: `Log Level`
 The `log_level` option controls the level of log output by the addon and can
 be changed to be more or less verbose, which might be useful when you are

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: "JK-BMS wired management"
-version: 3.7.6
+version: 3.7.7
 slug: "smartphoton_jkbms"
 description: JK-BMS Management via RS485 & CAN bus or TCP/IP Gateway
 url: https://domosimple.eu/forum/thread-917.html
@@ -46,6 +46,10 @@ options:
   mqttuser: "username"
   mqttpass: "password"
 
+  # Node-RED Auth Configuration
+  auth_username: ""
+  auth_password: ""
+
   # Telemetry
   Send_bip: true
 
@@ -64,6 +68,10 @@ schema:
   mqttadresse_port: str?
   mqttuser: str?
   mqttpass: password?
+
+  # Node-RED Auth Configuration
+  auth_username: str?
+  auth_password: password?
 
   # Telemetry
   Send_bip: bool

--- a/rootfs/etc/node-red/config.js
+++ b/rootfs/etc/node-red/config.js
@@ -1,10 +1,29 @@
+"use strict";
 console.log("✅ config.js is being loaded");
 
-const config = require("/config/smartphoton_jkbms/settings.js");
-
 const fs = require("fs");
-const options = JSON.parse(fs.readFileSync("/data/options.json", "utf8"));
+const crypto = require("crypto");
 const bcrypt = require("bcryptjs");
+const config = require("/config/smartphoton_jkbms/settings.js");
+const options = JSON.parse(fs.readFileSync("/data/options.json", "utf8"));
+
+const CRED_SECRET_FILE = "/data/credential-secret";
+const BCRYPT_COST = 10;
+
+// credentialSecret: generate once, persist forever (0600).
+// flows.json is rewritten from the template on every restart and MQTT creds
+// are read from add-on options at runtime, so there are no surviving
+// encrypted credentials from the old shared secret to migrate.
+let credentialSecret = null;
+try {
+  credentialSecret = fs.readFileSync(CRED_SECRET_FILE, "utf8").trim() || null;
+} catch (_) { /* will generate */ }
+if (!credentialSecret) {
+  credentialSecret = crypto.randomBytes(32).toString("hex");
+  const tmp = CRED_SECRET_FILE + ".tmp";
+  fs.writeFileSync(tmp, credentialSecret, { mode: 0o600 });
+  fs.renameSync(tmp, CRED_SECRET_FILE);
+}
 
 if ("theme" in options && options.theme !== "default") {
   config.editorTheme.theme = options.theme;
@@ -16,43 +35,41 @@ config.nodesDir = "/config/smartphoton_jkbms/nodes";
 config.uiPort = 1891;
 config.userDir = "/config/smartphoton_jkbms/";
 config.httpNodeRoot = "/endpoint";
+config.flowFilePretty = true;
+config.credentialSecret = credentialSecret;
 
 console.log("✅ Node-RED is using userDir =", config.userDir);
 console.log("✅ Node-RED is using uiPort =", config.uiPort);
 
-config.credentialSecret = "domosimple";
-config.flowFilePretty = true;
-
 config.contextStorage = {
   default: {
-    module: 'localfilesystem',
+    module: "localfilesystem",
     config: {
-      dir: '/config/smartphoton_jkbms/global-variables',
-      flushInterval: '5'
+      dir: "/config/smartphoton_jkbms/global-variables",
+      flushInterval: "5"
     }
   }
 };
 
-config.adminAuth = {
-  type: "credentials",
-  users: [
-    {
-      username: "pi",
-      password: "$2a$08$uGLFsGppdWnckZpomdNQveucw.zh8bkSWDO0Gnzj4Z0asqj91KKge",
-      permissions: "*"
-    }
-  ]
-};
-
-config.httpNodeAuth = {
-  user: "pi",
-  pass: "$2a$08$uGLFsGppdWnckZpomdNQveucw.zh8bkSWDO0Gnzj4Z0asqj91KKge"
-};
-
-config.httpStaticAuth = {
-  user: "pi",
-  pass: "$2a$08$uGLFsGppdWnckZpomdNQveucw.zh8bkSWDO0Gnzj4Z0asqj91KKge"
-};
+const authUser = (options.auth_username || "").trim();
+const authPass = (options.auth_password || "").trim();
+if (authUser && authPass) {
+  const hash = bcrypt.hashSync(authPass, BCRYPT_COST);
+  config.adminAuth = {
+    type: "credentials",
+    users: [{ username: authUser, password: hash, permissions: "*" }]
+  };
+  config.httpNodeAuth = { user: authUser, pass: hash };
+  config.httpStaticAuth = { user: authUser, pass: hash };
+  console.log("✅ Node-RED authentication enabled for editor and HTTP endpoints");
+} else {
+  const bar = "=".repeat(72);
+  console.warn(bar);
+  console.warn("⚠️  Node-RED editor and HTTP endpoints (port 1891) are UNPROTECTED.");
+  console.warn("⚠️  Set 'auth_username' and 'auth_password' in the add-on");
+  console.warn("⚠️  configuration to enable authentication.");
+  console.warn(bar);
+}
 
 if (options.log_level) {
   config.logging.console.level = options.log_level.toLowerCase();

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -3,6 +3,18 @@
 This image allows you to run the **JK-BMS-RS485 & CAN bus** as standalone container alongside **Home Assistant Docker** installation (without the Supervisor).  
 The image embeds the original Node-RED core implementation of the add-on and exposes its configuration via Docker environment variables.
 
+## Security note
+
+The standalone Docker image launches Node-RED with `--userDir /data` and no
+`--settings`, so **no authentication is enforced on port 1880**. This matches
+the upstream Node-RED Docker image. Put the container behind a reverse proxy
+with authentication, or bind it to a private network, before exposing it.
+
+The Home Assistant add-on path (separate from this standalone image) supports
+per-install Node-RED credentials via the `auth_username` and `auth_password`
+options. Wiring the same behaviour into the standalone path is a known
+follow-up.
+
 ## Build the Docker image
 
 ### Local build

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Passwort"
     description: "Passwort für den entsprechenden MQTT-Benutzer."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Add-on Nutzung"
     description: "Aktiviert einen Signalton beim Start. Es werden keine privaten Daten übertragen. Die Verarbeitung erfolgt gemäß DSGVO."

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -47,6 +47,15 @@ configuration:
     name: "🚩 MQTT → Password"
     description: "Password associated with the MQTT user."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Add-on usage"
     description: "Enable a beep to be sent at start-up. No private data is transmitted. Processing complies with the GDPR."

--- a/translations/es.yaml
+++ b/translations/es.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Contraseña"
     description: "Contraseña asociada al usuario MQTT."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Uso del Add-on"
     description: "Habilitar el envío de un pitido al arrancar. No se transmiten datos privados. El procesamiento cumple con el RGPD."

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Mot de passe"
     description: "Mot de passe associé à l'utilisateur MQTT."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Utilisation de l'Add-on"
     description: "Activer l'envoi d'un bip au démarrage. Aucune donnée privée n'est transmise. Le traitement est conforme au RGPD."

--- a/translations/it.yaml
+++ b/translations/it.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Password"
     description: "Password associata all'utente MQTT."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Utilizzo Add-on"
     description: "Abilita l'invio di un segnale acustico (beep) all'avvio. Non viene trasmesso alcun dato privato. Il trattamento è conforme al GDPR."

--- a/translations/pl.yaml
+++ b/translations/pl.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Hasło"
     description: "Hasło powiązane z użytkownikiem MQTT."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Korzystanie z dodatku"
     description: "Włącz sygnał dźwiękowy (beep) przy uruchamianiu. Żadne prywatne dane nie są przesyłane. Przetwarzanie jest zgodne z RODO (GDPR)."

--- a/translations/pt.yaml
+++ b/translations/pt.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Senha"
     description: "Senha associada ao usuário MQTT."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Uso do Add-on"
     description: "Ativar um sinal sonoro (bipe) na inicialização. Nenhum dado privado é transmitido. O processamento está em conformidade com o RGPD."

--- a/translations/ru.yaml
+++ b/translations/ru.yaml
@@ -46,6 +46,15 @@ configuration:
     name: "🚩 MQTT → Пароль"
     description: "Пароль, связанный с пользователем MQTT."
 
+  # Node-RED Auth Configuration Section
+  auth_username:
+    name: "🔐 Node-RED → Editor Username"
+    description: "Username for the Node-RED editor (port 1891) and HTTP endpoints. Leave blank to start Node-RED with no authentication (a warning will be logged)."
+
+  auth_password:
+    name: "🔐 Node-RED → Editor Password"
+    description: "Password for the Node-RED editor and HTTP endpoints. Also protects /endpoint/* and static files. Leave blank to disable authentication (not recommended — port 1891 is reachable on the LAN)."
+
   Send_bip:
     name: "📊 Использование аддона"
     description: "Включить звуковой сигнал (бип) при запуске. Личные данные не передаются. Обработка соответствует регламенту GDPR."


### PR DESCRIPTION
Closes #152.

## Summary

- Remove hardcoded Node-RED editor / HTTP credentials and the `credentialSecret` literal from `rootfs/etc/node-red/config.js`.
- Add `auth_username` and `auth_password` add-on options. When both are set, the password is bcrypt-hashed (cost 10) at startup and applied to `adminAuth`, `httpNodeAuth`, and `httpStaticAuth`. When either is blank, Node-RED starts unauthenticated and a warning banner is logged.
- Per-install random `credentialSecret`, generated on first launch and persisted to `/data/credential-secret` (mode 0600). Survives restarts.
- Bump add-on version to `3.7.7`.
- Add option labels to all 8 translation files (English in every file as a starting point — localisation welcome as a follow-up).
- Add CHANGELOG entry, DOCS.md "Node-RED authentication" subsection, and a security note in `standalone/README.md`.

## Design rationale

Matches the canonical HA Node-RED add-on ([`hassio-addons/addon-node-red`](https://github.com/hassio-addons/addon-node-red)): optional plaintext credentials, blank → no auth + warning, fresh bcrypt hash on each startup. The one deviation is that this add-on uses `ingress: false` and exposes port 1891 directly on the LAN, so the option description and DOCS.md explicitly recommend setting both.

No migration needed for existing users: the add-on already rewrites `flows.json` from the template on every restart (`init-nodered/run`), and MQTT credentials are read from add-on options at runtime via `global.get(...)`, so there are no surviving encrypted credentials to preserve from the old shared `credentialSecret`.

## Test plan

Tested on HAOS 17.3 with 6× JK-BMS via TCP gateway against Core `2026.5.0`, Supervisor `2026.05.1`:

- [x] Static: `node --check` on `config.js`, YAML round-trip on `config.yaml` and all 8 translations.
- [x] Audit: no bcrypt-style hashes remain anywhere in the repo; no `pi` username literals.
- [x] Blank options: warning banner appears, editor opens without login, `/data/credential-secret` is created.
- [x] Configured options: log shows `✅ Node-RED authentication enabled`, editor and `/endpoint/*` prompt for HTTP Basic and accept the configured pair.
- [x] Persistence: `credential-secret` file content unchanged across add-on restarts.
- [x] Legacy credentials: previous default login rejected with 401.
- [x] BMS data flow unchanged after upgrade: 6× BMS still poll, MQTT still publishes, dashboard still works.

## Out of scope

- Wiring `auth_username` / `auth_password` into the standalone Docker path (currently launches Node-RED without `--settings`, so `config.js` is not loaded there).
- Pinning `bcryptjs` (currently `"*"` in `package.json`).
- Splitting per-auth-surface credentials (editor vs `httpNodeAuth` vs `httpStaticAuth`). Current PR keeps the single shared pair to match existing behaviour.
- Community translations of the two new option labels.